### PR TITLE
Fix a bug selecting a shadowRoot of an element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2023-11-15
+
+- Fix a bug selecting a shadowRoot from an element
+
 ## [1.0.0] - 2023-11-14
 
 - Release of `shadow-dom-selector`

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -191,6 +191,15 @@ describe('ShadowDomSelector spec', () => {
         );
 
         expect(
+          shadowRootQuerySelector(
+            document.querySelector('section'),
+            '$'
+          )
+        ).to.equal(
+          document.querySelector('section').shadowRoot
+        );
+
+        expect(
           shadowRootQuerySelector('section$ .article$ ul$')
         ).to.null;
 
@@ -525,6 +534,15 @@ describe('ShadowDomSelector spec', () => {
           )
         ).to.equal(
           document.querySelector('section').shadowRoot.querySelector('article').shadowRoot
+        );
+
+        expect(
+          await asyncShadowRootQuerySelector(
+            document.querySelector('section'),
+            '$'
+          )
+        ).to.equal(
+          document.querySelector('section').shadowRoot
         );
 
         expect(

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -219,6 +219,12 @@ describe('ShadowDomSelector spec', () => {
           'You can not select a shadowRoot'
         );
 
+        expect(
+          () => shadowRootQuerySelector('$')
+        ).to.throw(
+          'You can not select a shadowRoot'
+        );
+
       });
   });
 
@@ -565,6 +571,13 @@ describe('ShadowDomSelector spec', () => {
 
         cy.wrap(null).then(() => {
           return asyncShadowRootQuerySelector('$ section$ article$')
+            .catch((error: Error) => {
+              expect(error.message).to.contain('You can not select a shadowRoot');
+            });
+        });
+
+        cy.wrap(null).then(() => {
+          return asyncShadowRootQuerySelector('$')
             .catch((error: Error) => {
               expect(error.message).to.contain('You can not select a shadowRoot');
             });

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -68,6 +68,18 @@ export function shadowRootQuerySelectorInternal(
     root: Document | Element
 ): ShadowRoot | null {
 
+    if (
+        path.length === 1 &&
+        !path[0].length
+    ) {
+        if (root instanceof Document) {
+            throw new SyntaxError(
+                getDocumentShadowRootError()
+            );
+        }
+        return root.shadowRoot;
+    }
+
     const lastElement = querySelectorInternal(
         path,
         root
@@ -202,6 +214,22 @@ export async function asyncShadowRootQuerySelectorInternal(
     retries: number,
     delay: number
 ): Promise<ShadowRoot | null> {
+
+    if (
+        path.length === 1 &&
+        !path[0].length
+    ) {
+        if (root instanceof Document) {
+            throw new SyntaxError(
+                getDocumentShadowRootError()
+            );
+        }
+        return getPromisableShadowRoot(
+            root,
+            retries,
+            delay
+        );
+    }
 
     const lastElement = await asyncQuerySelectorInternal(
         path,


### PR DESCRIPTION
This pull request fixes a bug in the `shadowRootQuerySelector` and `asyncShadowRootQuerySelector` methods. Trying to get the `shadowRoot` of an element was returning `null`:

```typescript
shadowRootQuerySelector(element, '$'); // returned null
```