### PR TITLE
Export `AsyncParams` and `AsyncSelectorProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.1] - 2023-12-04
+
+- Export `AsyncParams` and `AsyncSelectorProxy`
+
 ## [2.0.0] - 2023-12-03
 
 - Implement query selection through dot notation

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -8,7 +8,7 @@ export type AsyncSelectorBase = {
     asyncParams: AsyncParams;
 };
 
-export type AsyncSelectorInstance = AsyncSelectorBase & {
+export type AsyncSelectorInstance = Exclude<AsyncSelectorBase, '_element'> & {
     element: Promise<Document | Element | ShadowRoot | null>;
     all: Promise<NodeListOf<Element>>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     AsyncSelectorBase,
     AsyncSelectorProxy,
     AsyncParams
@@ -322,4 +322,9 @@ const getShadowDomSelectorProxy = (
             get: getter
         }
     ) as AsyncSelectorProxy;
+};
+
+export type {
+    AsyncParams,
+    AsyncSelectorProxy
 };


### PR DESCRIPTION
This pull request exports the types `AsyncParams` and `AsyncSelectorProxy` so they can be imported by clients.