### PR TITLE
Rename AsyncSelector to buildAsyncSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.2] - 2023-12-04
+
+- `AsyncSelector` has been renamed to `buildAsyncSelector`
+
 ## [2.0.1] - 2023-12-04
 
 - Export `AsyncParams` and `AsyncSelectorProxy`

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ asyncQuerySelectorAll('article$ div$ p')
   });
 
 // Using async dot notation
-import { AsyncSelector } from 'shadow-dom-selector';
+import { buildAsyncSelector } from 'shadow-dom-selector';
 
-const selector = AsyncSelector();
+const selector = buildAsyncSelector();
 
 selector.article.$.div.$.element
   .then((shadowRoot) => {
@@ -184,7 +184,7 @@ ShadowDomSelector.shadowRootQuerySelector;
 ShadowDomSelector.asyncQuerySelector;
 ShadowDomSelector.asyncQuerySelectorAll;
 ShadowDomSelector.asyncShadowRootQuerySelector;
-ShadowDomSelector.AsyncSelector;
+ShadowDomSelector.buildAsyncSelector;
 ```
 
 ## API
@@ -330,14 +330,14 @@ asyncShadowRootQuerySelector(root, selectors, asyncParams): Promise<ShadowRoot |
 }
 ```
 
-#### AsyncSelector
+#### buildAsyncSelector
 
 ```typescript
-AsyncSelector(root): AsyncSelectorProxy;
+buildAsyncSelector(root): AsyncSelectorProxy;
 ```
 
 ```typescript
-AsyncSelector(root, asyncParams): AsyncSelectorProxy;
+buildAsyncSelector(root, asyncParams): AsyncSelectorProxy;
 ```
 
 | Parameter    | Optional      | Description                                        |
@@ -366,17 +366,17 @@ This function returns an object with the next properties:
 }
 ```
 
-##### Examples of AsyncSelector
+##### Examples of buildAsyncSelector
 
 ```typescript
-const selector = AsyncSelector(); // AsyncSelectorProxy starting in the document with the default asyncParams
+const selector = buildAsyncSelector(); // AsyncSelectorProxy starting in the document with the default asyncParams
 await selector.element === document;
 await selector.all; // Empty Node list
 await selector.$; // null
 ```
 
 ```typescript
-const selector = AsyncSelector({
+const selector = buildAsyncSelector({
   retries: 100,
   delay: 50
 }); // AsyncSelectorProxy starting in the document and with custom asyncParams

--- a/cypress/e2e/async-selector.spec.cy.ts
+++ b/cypress/e2e/async-selector.spec.cy.ts
@@ -1,4 +1,4 @@
-describe('ShadowDomSelector AsyncSelector class spec', () => {
+describe('ShadowDomSelector buildAsyncSelector class spec', () => {
 
     beforeEach(() => {
         cy.visit('http://localhost:3000');
@@ -9,9 +9,9 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
-                const selector = AsyncSelector({
+                const selector = buildAsyncSelector({
                     retries: 1,
                     delay: 5
                 });
@@ -36,9 +36,9 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
-                const selector = AsyncSelector();
+                const selector = buildAsyncSelector();
 
                 const article = doc
                     .querySelector('section')
@@ -79,14 +79,14 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
                 const article = doc
                     .querySelector('section')
                     .shadowRoot
                     .querySelector('article');
 
-                const selector = AsyncSelector(article);
+                const selector = buildAsyncSelector(article);
 
                 expect(await selector.element).to.equal(article);
         
@@ -105,9 +105,9 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
         cy.window()
             .then(async (win) => {
 
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
-                const selector = AsyncSelector({
+                const selector = buildAsyncSelector({
                     retries: 100
                 });
 
@@ -128,9 +128,9 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
         cy.window()
             .then(async (win) => {
 
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
-                const selector = AsyncSelector({
+                const selector = buildAsyncSelector({
                     retries: 7,
                     delay: 13
                 });
@@ -152,13 +152,13 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
-                const selector = AsyncSelector({
+                const selector = buildAsyncSelector({
                     delay: 5
                 });
 
-                const selectorFromSection = AsyncSelector(
+                const selectorFromSection = buildAsyncSelector(
                     doc.querySelector('section').shadowRoot,
                     {
                         delay: 5

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,14 +186,14 @@ export async function asyncShadowRootQuerySelector(
     );
 }
 
-export function AsyncSelector(
+export function buildAsyncSelector(
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
-export function AsyncSelector(
+export function buildAsyncSelector(
     root: Document | Element | ShadowRoot,
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
-export function AsyncSelector (
+export function buildAsyncSelector (
     firstParameter: Document | Element | ShadowRoot | AsyncParams,
     secondParameter?: AsyncParams
 ): AsyncSelectorProxy {


### PR DESCRIPTION
`AsyncSelector` has been renamed to `buildAsyncSelector`.