### PR TITLE
Allow `buildAsyncSelector` method to receive a Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.3] - 2023-12-04
+
+- Allow `buildAsyncSelector` method to receive a Promise
+
 ## [2.0.2] - 2023-12-04
 
 - `AsyncSelector` has been renamed to `buildAsyncSelector`

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,11 +190,11 @@ export function buildAsyncSelector(
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
 export function buildAsyncSelector(
-    root: Document | Element | ShadowRoot,
+    root: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot>,
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
 export function buildAsyncSelector (
-    firstParameter: Document | Element | ShadowRoot | AsyncParams,
+    firstParameter: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot> | AsyncParams,
     secondParameter?: AsyncParams
 ): AsyncSelectorProxy {
     if (firstParameter instanceof Node) {


### PR DESCRIPTION
This pull request allos the `buildAsyncSelector` to receive also a Promise.