### PR TITLE
Fix a bug in `buildAsyncSelector`, if a Promise was sent, `document` was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.4] - 2023-12-04
+
+- Fix a bug in `buildAsyncSelector`, if a Promise was sent, `document` was used
+
 ## [2.0.3] - 2023-12-04
 
 - Allow `buildAsyncSelector` method to receive a Promise

--- a/cypress/e2e/async-selector.spec.cy.ts
+++ b/cypress/e2e/async-selector.spec.cy.ts
@@ -105,11 +105,26 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
         cy.window()
             .then(async (win) => {
 
+                const doc = win.document;
                 const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
 
                 const selector = buildAsyncSelector({
                     retries: 100
                 });
+
+                const selectorFromDelayedSection = buildAsyncSelector(
+                    new win.Promise<Element>((resolve) => {
+                        setTimeout(() => {
+                            resolve(
+                                doc.querySelector('section')
+                            );
+                        }, 500);
+                    }),
+                    {
+                        retries: 20,
+                        delay: 50
+                    }
+                );
 
                 expect(
                     await selector['#section'].$['.article'].$['.delayed-list-container'].$.ul['li:nth-of-type(2)'].element
@@ -118,6 +133,12 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 expect(
                     (await selector.section.$.article.$['.delayed-list-container'].$['ul > li'].all).length
                 ).to.equal(3);
+
+                expect(
+                    await selectorFromDelayedSection.element
+                ).to.equal(
+                    doc.querySelector('section')
+                );
 
             });
 
@@ -165,6 +186,18 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                     }
                 );
 
+                const selectorFromDelayedSection = buildAsyncSelector(
+                    new Promise<ShadowRoot>((resolve) => {
+                        setTimeout(() => {
+                            resolve(doc.querySelector('section').shadowRoot);
+                        }, 500);
+                    }),
+                    {
+                        retries: 20,
+                        delay: 50
+                    }
+                );
+
                 expect(
                     await selector.article.element
                 ).to.null;
@@ -179,6 +212,10 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
 
                 expect(
                     await selectorFromSection.$.element
+                ).to.null;
+
+                expect(
+                    await selectorFromDelayedSection.$.element
                 ).to.null;
 
                 expect(

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -4,7 +4,7 @@ export interface AsyncParams {
 }
 
 export type AsyncSelectorBase = {
-    _element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | ShadowRoot | null>;
+    _element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | Element | ShadowRoot | null>;
     asyncParams: AsyncParams;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,14 +190,17 @@ export function buildAsyncSelector(
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
 export function buildAsyncSelector(
-    root: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot>,
+    root?: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot>,
     asyncParams?: AsyncParams
 ): AsyncSelectorProxy;
 export function buildAsyncSelector (
-    firstParameter: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot> | AsyncParams,
+    firstParameter?: Document | Element | ShadowRoot | Promise<Element | NodeListOf<Element> | ShadowRoot> | AsyncParams,
     secondParameter?: AsyncParams
 ): AsyncSelectorProxy {
-    if (firstParameter instanceof Node) {
+    if (
+        firstParameter instanceof Node ||
+        firstParameter instanceof Promise
+    ) {
         const params = {
             retries: DEFAULT_RETRIES,
             delay: DEFAULT_DELAY,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -143,7 +143,7 @@ export function getMustErrorText(
 }
 
 export function getElementPromise(
-    element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | ShadowRoot | null>
+    element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | Element | ShadowRoot | null>
 ): Promise<Document | Element | NodeListOf<Element> | ShadowRoot | null> {
     return element instanceof Promise
         ? element


### PR DESCRIPTION
This pull rquest fixes a bug in the `buildAsyncSelector` utility that was using the `document` if one sent a `Promise` as root.