### PR TITLE
Refactor the dot notation syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0] - 2023-12-05
+
+- Refactor the `buildAsyncSelector` from a function to a class (`AsyncSelector`)
+- Dot notation queries have changed to make them more type safe
+
 ## [2.0.4] - 2023-12-04
 
 - Fix a bug in `buildAsyncSelector`, if a Promise was sent, `document` was used

--- a/README.md
+++ b/README.md
@@ -119,23 +119,23 @@ asyncQuerySelectorAll('article$ div$ p')
   });
 
 // Using async dot notation
-import { buildAsyncSelector } from 'shadow-dom-selector';
+import { AsyncSelector } from 'shadow-dom-selector';
 
-const selector = buildAsyncSelector();
+const selector = new AsyncSelector();
 
-selector.article.$.div.$.element
+selector.query('article').$.query('div').$.element
   .then((shadowRoot) => {
     // Do stuff with the shadowRoot
     // If it is not found after all the retries, it will return null
   });
 
-selector.article.$.div.$['section > h1'].element
+selector.query('article').$.query('div').$.query('section > h1').element
   .then((h1) => {
     // Do stuff with the h1 element
     // If it is not found after all the retries, it will return null
   });
 
-selector.article.$.div.$.p.all
+selector.query('article').$.query('div').$.query('p').all
   .then((paragraphs) => {
     // Do stuff with the paragraphs
     // If they are not found after all the retries, it will return an empty NodeList
@@ -184,7 +184,7 @@ ShadowDomSelector.shadowRootQuerySelector;
 ShadowDomSelector.asyncQuerySelector;
 ShadowDomSelector.asyncQuerySelectorAll;
 ShadowDomSelector.asyncShadowRootQuerySelector;
-ShadowDomSelector.buildAsyncSelector;
+ShadowDomSelector.AsyncSelector;
 ```
 
 ## API
@@ -201,8 +201,8 @@ querySelector(root, selectors): Element | null;
 
 | Parameter    | Optional      | Description                                        |
 | ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors cannot end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### querySelectorAll
 
@@ -216,8 +216,8 @@ querySelectorAll(root, selectors): NodeListOf<Element>;
 
 | Parameter    | Optional      | Description                                        |
 | ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors cannot end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### shadowRootQuerySelector
 
@@ -231,8 +231,8 @@ shadowRootQuerySelector(root, selectors): ShadowRoot | null;
 
 | Parameter    | Optional      | Description                                        |
 | ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### asyncQuerySelector
 
@@ -252,11 +252,11 @@ asyncQuerySelector(selectors, asyncParams): Promise<Element | null>;
 asyncQuerySelector(root, selectors, asyncParams): Promise<Element | null>;
 ```
 
-| Parameter    | Optional      | Description                                        |
-| ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors cannot end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
-| asyncParams  | yes           | An object containing the parameters which control the retries |
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
 
 ```typescript
 // asyncParams properties
@@ -284,11 +284,11 @@ asyncQuerySelectorAll(selectors, asyncParams): Promise<NodeListOf<Element>>;
 asyncQuerySelectorAll(root, selectors, asyncParams): Promise<NodeListOf<Element>>;
 ```
 
-| Parameter    | Optional      | Description                                        |
-| ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors cannot end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
-| asyncParams  | yes           | An object containing the parameters which control the retries |
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
 
 ```typescript
 // asyncParams properties
@@ -316,11 +316,11 @@ asyncShadowRootQuerySelector(selectors, asyncParams): Promise<ShadowRoot | null>
 asyncShadowRootQuerySelector(root, selectors, asyncParams): Promise<ShadowRoot | null>;
 ```
 
-| Parameter    | Optional      | Description                                        |
-| ------------ | ------------- | -------------------------------------------------- |
-| selectors    | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
-| root         | yes           | The element from where the query should be performed, it defaults to `document` |
-| asyncParams  | yes           | An object containing the parameters which control the retries |
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
 
 ```typescript
 // asyncParams properties
@@ -330,20 +330,24 @@ asyncShadowRootQuerySelector(root, selectors, asyncParams): Promise<ShadowRoot |
 }
 ```
 
-#### buildAsyncSelector
+#### AsyncSelector class
 
 ```typescript
-buildAsyncSelector(root): AsyncSelectorProxy;
+new AsyncSelector();
 ```
 
 ```typescript
-buildAsyncSelector(root, asyncParams): AsyncSelectorProxy;
+new AsyncSelector(root);
 ```
 
-| Parameter    | Optional      | Description                                        |
-| ------------ | ------------- | -------------------------------------------------- |
-| root         | yes           | The element or shadowRoot from where the query should be performed, it defaults to `document` |
-| asyncParams  | yes           | An object containing the parameters which control the retries |
+```typescript
+new AsyncSelector(root, asyncParams);
+```
+
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `root`        | yes           | The element or shadowRoot from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
 
 ```typescript
 // asyncParams properties
@@ -353,37 +357,42 @@ buildAsyncSelector(root, asyncParams): AsyncSelectorProxy;
 }
 ```
 
-This function returns an object with the next properties:
+The instances of this class have the next properties:
+
+| Property         | Type                                 | Description                                                      |
+| ---------------- | ------------------------------------ | ---------------------------------------------------------------- |
+| `element`        | Promise<Element | ShadowRoot | null> | A promise that resolves in the queried element                   |
+| `all`            | Promise<NodeListOf<Element>>         | A promise that resolves in a Nodelist with all queried elements  |
+| `$`              | Promise<ShadowRoot | null>           | A promise that resolves in the shadowRoot of the queried element |
+| `asyncParams`    | Same `asyncParams` previously shown  | An object containing the parameters which control the retries    |
+
+An the next methods:
+
+| Method                    | Return                  | Description                                                      |
+| ------------------------- | ----------------------- | ---------------------------------------------------------------- |
+| `eq(index: number)`       | Promise<Element | null> | A promise that resolves in the element in the 0 index position of the queried elements |
+| `query(selector: string)` | AsyncSelector           | Perform a query an returns a new AsyncSelector instance |
+
+##### Examples of the AsyncSelector class
 
 ```typescript
-// AsyncSelectorProxy properties
-{
-  element: Promise<Document | Element | ShadowRoot | null>; // A promise that resolves in the first queried element
-  all: Promise<NodeListOf<Element>>; // A promise that resolves in all the queried elements
-  $: Promise<ShadowRoot | null>; // A promise that resolves in the shadowRoot of the first queried element
-  asyncParams: { retries: number; delay: number; } // The asyncParameters being used in the chain
-  [any other property]: AsyncSelectorProxy; // Returns another AsyncSelectorProxy pointing to the element queried by the property name
-}
-```
-
-##### Examples of buildAsyncSelector
-
-```typescript
-const selector = buildAsyncSelector(); // AsyncSelectorProxy starting in the document with the default asyncParams
+const selector = new AsyncSelector(); // Starting to query in the document with the default asyncParams
 await selector.element === document;
 await selector.all; // Empty Node list
 await selector.$; // null
+await selector.eq(0); // null
 ```
 
 ```typescript
-const selector = buildAsyncSelector({
+const selector = AsyncSelector({
   retries: 100,
   delay: 50
-}); // AsyncSelectorProxy starting in the document and with custom asyncParams
-await selector.section.$.element === document.querySelector('section').shadowRoot;
-await selector.section.$.all; // Empty Node list
-await selector.section.$.article.all === document.querySelector('section').shadowRoot.querySelectorAll('article');
-selector.section.$.article.asyncParams; // { retries: 100, delay: 50 }
+}); // Starting to query in the document with custom asyncParams
+await selector.query('section').$.element === document.querySelector('section').shadowRoot;
+await selector.query('section').$.all; // Empty Node list
+await selector.query('section').$.query('article').all === document.querySelector('section').shadowRoot.querySelectorAll('article');
+await selector.query('section').$.query('ul li').eq(1) === document.querySelector('section').shadowRoot.querySelectorAll('ul li')[1];
+selector.query('section').$.query('article').asyncParams; // { retries: 100, delay: 50 }
 ```
 
 [Shadow DOM]: https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM

--- a/cypress/e2e/async-selector.spec.cy.ts
+++ b/cypress/e2e/async-selector.spec.cy.ts
@@ -1,4 +1,4 @@
-describe('ShadowDomSelector buildAsyncSelector class spec', () => {
+describe('ShadowDomSelector AsyncSelector class spec', () => {
 
     beforeEach(() => {
         cy.visit('http://localhost:3000');
@@ -9,9 +9,9 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
-                const selector = buildAsyncSelector({
+                const selector = new AsyncSelector({
                     retries: 1,
                     delay: 5
                 });
@@ -19,13 +19,13 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 const section = doc.querySelector('section');
                 const allSections = doc.querySelectorAll('section');
 
-                expect(await selector.section.element).to.equal(section);
-                expect(await selector.section.all).to.deep.equal(allSections);
-                expect(await selector.li.element).to.null;
-                expect(await selector.article.$.element).to.null;
-                expect((await selector.li.all).length).to.equal(0);
-                expect((await selector.article.$.div.$.span.all).length).to.equal(0);
-                expect(await selector.li.all).to.be.instanceOf(win.NodeList);
+                expect(await selector.query('section').element).to.equal(section);
+                expect(await selector.query('section').all).to.deep.equal(allSections);
+                expect(await selector.query('li').element).to.null;
+                expect(await selector.query('article').$.element).to.null;
+                expect((await selector.query('li').all).length).to.equal(0);
+                expect((await selector.query('article').$.query('div').$.query('span').all).length).to.equal(0);
+                expect(await selector.query('li').all).to.be.instanceOf(win.NodeList);
 
             });
     });
@@ -36,9 +36,9 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
-                const selector = buildAsyncSelector();
+                const selector = new AsyncSelector();
 
                 const article = doc
                     .querySelector('section')
@@ -52,19 +52,19 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 const allLis = ul.querySelectorAll('li');
 
                 expect(
-                    await selector.section.$.article.element
+                    await selector.query('section').$.query('article').element
                 ).to.equal(
                     article
                 );
 
                 expect(
-                    await selector['#section'].$['.article'].element
+                    await selector.query('#section').$.query('.article').element
                 ).to.equal(
                     article
                 );
 
                 expect(
-                    await selector.section.$.article.$.ul.li.all
+                    await selector.query('section').$.query('article').$.query('ul li').all
                 ).to.deep.equal(
                     allLis
                 );
@@ -79,19 +79,19 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
                 const article = doc
                     .querySelector('section')
                     .shadowRoot
                     .querySelector('article');
 
-                const selector = buildAsyncSelector(article);
+                const selector = new AsyncSelector(article);
 
                 expect(await selector.element).to.equal(article);
         
                 expect(
-                    await selector.$.ul.element
+                    await selector.$.query('ul').element
                 ).to.equal(
                     article.shadowRoot.querySelector('ul')
                 );
@@ -106,13 +106,13 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
-                const selector = buildAsyncSelector({
+                const selector = new AsyncSelector({
                     retries: 100
                 });
 
-                const selectorFromDelayedSection = buildAsyncSelector(
+                const selectorFromDelayedSection = new AsyncSelector(
                     new win.Promise<Element>((resolve) => {
                         setTimeout(() => {
                             resolve(
@@ -127,11 +127,15 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 );
 
                 expect(
-                    await selector['#section'].$['.article'].$['.delayed-list-container'].$.ul['li:nth-of-type(2)'].element
+                    await selector.query('#section').$.query('.article').$.query('.delayed-list-container').$.query('ul li:nth-of-type(2)').element
                 ).to.text('Delayed List item 2');
 
                 expect(
-                    (await selector.section.$.article.$['.delayed-list-container'].$['ul > li'].all).length
+                    await selector.query('#section').$.query('.article').$.query('.delayed-list-container').$.query('ul li').eq(1)
+                ).to.text('Delayed List item 2');
+
+                expect(
+                    (await selector.query('section').$.query('article').$.query('.delayed-list-container').$.query('ul > li').all).length
                 ).to.equal(3);
 
                 expect(
@@ -149,15 +153,15 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
         cy.window()
             .then(async (win) => {
 
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
-                const selector = buildAsyncSelector({
+                const selector = new AsyncSelector({
                     retries: 7,
                     delay: 13
                 });
 
                 expect(
-                    selector.section.$.asyncParams
+                    selector.query('section').$.asyncParams
                 ).to.deep.equal({
                     retries: 7,
                     delay: 13
@@ -173,20 +177,20 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
             .then(async (win) => {
 
                 const doc = win.document;
-                const buildAsyncSelector = win.ShadowDomSelector.buildAsyncSelector;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
 
-                const selector = buildAsyncSelector({
+                const selector = new AsyncSelector({
                     delay: 5
                 });
 
-                const selectorFromSection = buildAsyncSelector(
+                const selectorFromSection = new AsyncSelector(
                     doc.querySelector('section').shadowRoot,
                     {
                         delay: 5
                     }
                 );
 
-                const selectorFromDelayedSection = buildAsyncSelector(
+                const selectorFromDelayedSection = new AsyncSelector(
                     new Promise<ShadowRoot>((resolve) => {
                         setTimeout(() => {
                             resolve(doc.querySelector('section').shadowRoot);
@@ -199,7 +203,11 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 );
 
                 expect(
-                    await selector.article.element
+                    await selector.query('article').element
+                ).to.null;
+
+                expect(
+                    await selector.query('section').query('div').element
                 ).to.null;
 
                 expect(
@@ -207,7 +215,7 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 ).to.null;
 
                 expect(
-                    await selector.section.$.$.element
+                    await selector.query('section').$.$.element
                 ).to.null;
 
                 expect(
@@ -221,6 +229,14 @@ describe('ShadowDomSelector buildAsyncSelector class spec', () => {
                 expect(
                     (await selector.all).length
                 ).to.equal(0);
+
+                expect(
+                    await selector.eq(0)
+                ).to.null;
+
+                expect(
+                    await selector.query('section').eq(10)
+                ).to.null;
 
             });
 

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -2,17 +2,3 @@ export interface AsyncParams {
     retries?: number;
     delay?: number;
 }
-
-export type AsyncSelectorBase = {
-    _element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | Element | ShadowRoot | null>;
-    asyncParams: AsyncParams;
-};
-
-export type AsyncSelectorInstance = Exclude<AsyncSelectorBase, '_element'> & {
-    element: Promise<Document | Element | ShadowRoot | null>;
-    all: Promise<NodeListOf<Element>>;
-};
-
-export type AsyncSelectorProxy = AsyncSelectorInstance & {
-    [prop: string]: AsyncSelectorProxy;
-};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,4 +3,3 @@ export const HOST_SELECTOR = ':host';
 export const INVALID_SELECTOR = 'invalid selector';
 export const DEFAULT_RETRIES = 10;
 export const DEFAULT_DELAY = 10;
-export const ELEMENT_PROP = 'element';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,8 +4,3 @@ export const INVALID_SELECTOR = 'invalid selector';
 export const DEFAULT_RETRIES = 10;
 export const DEFAULT_DELAY = 10;
 export const ELEMENT_PROP = 'element';
-export enum ShadowDomSelectorProps {
-    ALL = 'all',
-    ELEMENT = 'element',
-    PARAMS = 'asyncParams'
-}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -142,9 +142,9 @@ export function getMustErrorText(
     return `${method} must be used with a selector ending in a shadowRoot (${SHADOW_ROOT_SELECTOR}). If you don't want to select a shadowRoot, use ${insteadMethod} instead.`;
 }
 
-export function getElementPromise(
-    element: Document | Element | ShadowRoot | Promise<NodeListOf<Element> | Element | ShadowRoot | null>
-): Promise<Document | Element | NodeListOf<Element> | ShadowRoot | null> {
+export function getElementPromise<T extends Document | Element | ShadowRoot>(
+    element: T | Promise<NodeListOf<Element> | T | null>
+): Promise<T | NodeListOf<Element> | null> {
     return element instanceof Promise
         ? element
         : Promise.resolve(element);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "module": "esnext",
-    "target": "ES5",
+    "target": "ES2015",
     "lib": ["DOM", "ES2017"],
     "types": ["cypress", "node"],
     "moduleResolution": "node",


### PR DESCRIPTION
This pull request refactors the dot notation syntax to make it more type friendly.

```typecript
import { buildAsyncSelector } from 'shadow-dom-selector';
const selector = buildAsyncSelector();
selector.article.$.div.$.element
```

Becomes

```typescript
import { AsyncSelector } from 'shadow-dom-selector';
const selector = new AsyncSelector();
selector.query('article').$.query('div').$.element;
```