### PR TITLE
Implement new methods to query for elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.0.0] - 2023-12-15
+
+- Implement a `deepQuerySelector` method to query for elements even if they are deep in the shadowDOM tree
+- Implement a `deepQuerySelectorAll` method to perform a querySelectorAll even if the elements are deep in the shadowDOM tree
+- Implement an `asyncDeepQuerySelector` method to query in an async way for elements even if they are deep in the shadowDOM tree
+- Implement an `asyncDeepQuerySelectorAll` method to perform an asynchronous querySelectorAll even if the elements are deep in the shadowDOM tree
+- Implement a `deepQuery` method in the `AsyncSelector` class to query for elements even if they are deep in the shadowDOM tree
+
 ## [3.0.1] - 2023-12-13
 
 - Removed private class properties to make the code ES5 compliant

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Having a DOM tree formed of Shadow DOM subtrees like the next one:
 If one wants to query for the `li` elements, it is required to do this:
 
 ```javascript
-const secondLi = document.querySelector('section').shadowRoot.querySelector('article').shadowRoot.querySelector('ul > li');
+const firstLi = document.querySelector('section').shadowRoot.querySelector('article').shadowRoot.querySelector('ul > li');
 
 const allLis = document.querySelector('section').shadowRoot.querySelector('article').shadowRoot.querySelectorAll('ul > li');
 
@@ -40,11 +40,20 @@ const shadow = document.querySelector('section').shadowRoot.querySelector('artic
 ```javascript
 // $ character at the end of a selector means to select its Shadom DOM
 
-import { querySelector, querySelectorAll, shadowRootQuerySelector } from 'shadow-dom-selector';
+import {
+  querySelector,
+  querySelectorAll,
+  shadowRootQuerySelector,
+  deepQuerySelector,
+  deepQuerySelectorAll
+} from 'shadow-dom-selector';
 
-const secondLi querySelector('section$ article$ ul > li');
-const allLis querySelectorAll('section$ article$ ul > li');
+const firstLi = querySelector('section$ article$ ul > li');
+const allLis = querySelectorAll('section$ article$ ul > li');
 const shadow = shadowRootQuerySelector('section$ article$');
+
+const deepFirstLi = deepQuerySelector('li');
+const deepAllLi = deepQuerySelectorAll('li');
 ```
 
 It will traverse all the Shadow DOM subtrees removing all the hassle of writing long concatenated queries.
@@ -85,11 +94,19 @@ const elements = document.querySelector('article')?.shadowRoot?.querySelector('d
 Which will return `undefined` if some element doesn‘t exist. With `shadow-dom-selector`, you just need to write the query and it will return the same that is returned by the native `querySelector` and `querySelectorAll` if the query cannot be satisfied.
 
 ```javascript
-import { querySelector, querySelectorAll, shadowRootQuerySelector } from 'shadow-dom-selector';
+import {
+  querySelector,
+  querySelectorAll,
+  shadowRootQuerySelector,
+  deepQuerySelector,
+  deepQuerySelectorAll
+} from 'shadow-dom-selector';
 
 const shadow = shadowRootQuerySelector('article$ div$'); // null
 const element = querySelector('article$ div$ section > h1'); // null
 const elements = querySelectorAll('article$ div$ p'); // empty NodeList
+const deepElement = deepQuerySelector('span') // null;
+const deepElements = deepQuerySelectorAll('p'); // empty NodeList
 ```
 
 ### Async queries
@@ -98,7 +115,13 @@ If the elements are not already rendered into the DOM in the moment that the que
 
 ```javascript
 // Using the async methods
-import { asyncQuerySelector, asyncQuerySelectorAll, asyncShadowRootQuerySelector } from 'shadow-dom-selector';
+import {
+  asyncQuerySelector,
+  asyncQuerySelectorAll,
+  asyncShadowRootQuerySelector,
+  asyncDeepQuerySelector,
+  asyncDeepQuerySelectorAll
+} from 'shadow-dom-selector';
 
 asyncShadowRootQuerySelector('article$ div$')
   .then((shadowRoot) => {
@@ -118,7 +141,19 @@ asyncQuerySelectorAll('article$ div$ p')
       // If they are not found after all the retries, it will return an empty NodeList
   });
 
-// Using async dot notation
+asyncDeepQuerySelector('h1')
+  .then((h1) => {
+      // Do stuff with the h1 element
+      // If it is not found after all the retries, it will return null
+  });
+
+asyncDeepQuerySelectorAll('p')
+  .then((paragraphs) => {
+      // Do stuff with the paragraphs
+      // If they are not found after all the retries, it will return an empty NodeList
+  });
+
+// Using de AsyncSelector class
 import { AsyncSelector } from 'shadow-dom-selector';
 
 const selector = new AsyncSelector();
@@ -136,6 +171,18 @@ selector.query('article').$.query('div').$.query('section > h1').element
   });
 
 selector.query('article').$.query('div').$.query('p').all
+  .then((paragraphs) => {
+    // Do stuff with the paragraphs
+    // If they are not found after all the retries, it will return an empty NodeList
+  });
+
+selector.deepQuery('h1').element
+  .then((h1) => {
+    // Do stuff with the h1 element
+    // If it is not found after all the retries, it will return null
+  });
+
+selector.deepQuery('p').all
   .then((paragraphs) => {
     // Do stuff with the paragraphs
     // If they are not found after all the retries, it will return an empty NodeList
@@ -179,10 +226,14 @@ It is possible to include a compiled version of the package directly in an HTML 
 ```javascript
 /* There will be a global variable named ShadowDomSelector containing all the functions */
 ShadowDomSelector.querySelector;
+ShadowDomSelector.deepQuerySelector;
 ShadowDomSelector.querySelectorAll;
+ShadowDomSelector.deepQuerySelectorAll;
 ShadowDomSelector.shadowRootQuerySelector;
 ShadowDomSelector.asyncQuerySelector;
+ShadowDomSelector.asyncDeepQuerySelector;
 ShadowDomSelector.asyncQuerySelectorAll;
+ShadowDomSelector.asyncDeepQuerySelectorAll;
 ShadowDomSelector.asyncShadowRootQuerySelector;
 ShadowDomSelector.AsyncSelector;
 ```
@@ -190,6 +241,8 @@ ShadowDomSelector.AsyncSelector;
 ## API
 
 #### querySelector
+
+Performs a query selection passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 querySelector(selectors): Element | null;
@@ -201,10 +254,31 @@ querySelector(root, selectors): Element | null;
 
 | Parameter    | Optional      | Description                                        |
 | ------------ | ------------- | -------------------------------------------------- |
-| `selectors`  | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
+| `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
+
+#### deepQuerySelector
+
+Performs a query selection of an element searching for it recursively in the whole DOM tree even if it needs to pass through the `shadowRoots` of elements.
+
+>Note: use this method carefully, depending on the extension of your DOM tree, it could be an expensive task in terms of resources. Do this when you need to query for an element that could appear in any part of the DOM tree so you don‘t know its exact position, otherwise, the `querySelector` method is recommended.
+
+```typescript
+deepQuerySelector(selectors): Element | null;
+```
+
+```typescript
+deepQuerySelector(root, selectors): Element | null;
+```
+
+| Parameter    | Optional      | Description                                        |
+| ------------ | ------------- | -------------------------------------------------- |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
 | `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### querySelectorAll
+
+Performs a `querySelectionAll` query passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 querySelectorAll(selectors): NodeListOf<Element>;
@@ -216,10 +290,31 @@ querySelectorAll(root, selectors): NodeListOf<Element>;
 
 | Parameter    | Optional      | Description                                        |
 | ------------ | ------------- | -------------------------------------------------- |
-| `selectors`  | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
+| `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
+
+#### deepQuerySelectorAll
+
+Performs a `querySelectionAll` query of elements searching for them recursively in the whole DOM tree even if it needs to pass through the `shadowRoots` of elements.
+
+>Note: use this method carefully, depending on the extension of your DOM tree, it could be an expensive task in terms of resources. Do this when you need to query for elements that could appear in any part of the DOM tree so you don‘t know their exact position, otherwise, the `querySelectionAll` method is recommended.
+
+```typescript
+deepQuerySelectorAll(selectors): NodeListOf<Element>;
+```
+
+```typescript
+deepQuerySelectorAll(root, selectors): NodeListOf<Element>;
+```
+
+| Parameter    | Optional      | Description                                        |
+| ------------ | ------------- | -------------------------------------------------- |
+| `selectors`  | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
 | `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### shadowRootQuerySelector
+
+Performs a query selection of a `shadowRoot` passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 shadowRootQuerySelector(selectors): ShadowRoot | null;
@@ -235,6 +330,8 @@ shadowRootQuerySelector(root, selectors): ShadowRoot | null;
 | `root`       | yes           | The element from where the query should be performed, it defaults to `document` |
 
 #### asyncQuerySelector
+
+Performs an asynchronous query selection passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 asyncQuerySelector(selectors): Promise<Element | null>;
@@ -254,7 +351,43 @@ asyncQuerySelector(root, selectors, asyncParams): Promise<Element | null>;
 
 | Parameter     | Optional      | Description                                        |
 | ------------- | ------------- | -------------------------------------------------- |
-| `selectors`   | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
+| `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
+
+```typescript
+// asyncParams properties
+{
+  retries?: number; // how many retries before giving up (defaults to 10)
+  delay?: number; // delay between each retry (defaults to 10)
+}
+```
+
+#### asyncDeepQuerySelector
+
+Performs an asynchronous query selection of an element searching for it recursively in the whole DOM tree even if it needs to pass through the `shadowRoots` of elements.
+
+>Note: use this method carefully, depending on the extension of your DOM tree, it could be an expensive task in terms of resources. Do this when you need to query for an element that could appear in any part of the DOM tree so you don‘t know its exact position, otherwise, the `asyncQuerySelector` method is recommended.
+
+```typescript
+asyncDeepQuerySelector(selectors): Promise<Element | null>;
+```
+
+```typescript
+asyncDeepQuerySelector(root, selectors): Promise<Element | null>;
+```
+
+```typescript
+asyncDeepQuerySelector(selectors, asyncParams): Promise<Element | null>;
+```
+
+```typescript
+asyncDeepQuerySelector(root, selectors, asyncParams): Promise<Element | null>;
+```
+
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
 | `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
 | `asyncParams` | yes           | An object containing the parameters which control the retries |
 
@@ -267,6 +400,8 @@ asyncQuerySelector(root, selectors, asyncParams): Promise<Element | null>;
 ```
 
 #### asyncQuerySelectorAll
+
+Performs an asynchronous `querySelectionAll` query passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 asyncQuerySelectorAll(selectors): Promise<NodeListOf<Element>>;
@@ -286,7 +421,43 @@ asyncQuerySelectorAll(root, selectors, asyncParams): Promise<NodeListOf<Element>
 
 | Parameter     | Optional      | Description                                        |
 | ------------- | ------------- | -------------------------------------------------- |
-| `selectors`   | no            | A string containing one or more selectors to match. Selectors must end in a Shadow DOM (`$`) |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
+| `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
+| `asyncParams` | yes           | An object containing the parameters which control the retries |
+
+```typescript
+// asyncParams properties
+{
+  retries?: number; // how many retries before giving up (defaults to 10)
+  delay?: number; // delay between each retry (defaults to 10)
+}
+```
+
+#### asyncDeepQuerySelectorAll
+
+Performs an asynchronous `querySelectionAll` query of elements searching for them recursively in the whole DOM tree even if it needs to pass through the `shadowRoots` of elements.
+
+>Note: use this method carefully, depending on the extension of your DOM tree, it could be an expensive task in terms of resources. Do this when you need to query for elements that could appear in any part of the DOM tree so you don‘t know their exact position, otherwise, the `asyncQuerySelectorAll` method is recommended.
+
+```typescript
+asyncDeepQuerySelectorAll(selectors): Promise<NodeListOf<Element>>;
+```
+
+```typescript
+asyncDeepQuerySelectorAll(root, selectors): Promise<NodeListOf<Element>>;
+```
+
+```typescript
+asyncDeepQuerySelectorAll(selectors, asyncParams): Promise<NodeListOf<Element>>;
+```
+
+```typescript
+asyncDeepQuerySelectorAll(root, selectors, asyncParams): Promise<NodeListOf<Element>>;
+```
+
+| Parameter     | Optional      | Description                                        |
+| ------------- | ------------- | -------------------------------------------------- |
+| `selectors`   | no            | A string containing one or more selectors to match. Selectors may not end in a Shadow DOM (`$`) |
 | `root`        | yes           | The element from where the query should be performed, it defaults to `document` |
 | `asyncParams` | yes           | An object containing the parameters which control the retries |
 
@@ -299,6 +470,8 @@ asyncQuerySelectorAll(root, selectors, asyncParams): Promise<NodeListOf<Element>
 ```
 
 #### asyncShadowRootQuerySelector
+
+Performs an asynchronous query selection of a `shadowRoot` passing through the `shadowRoot` of elements if you add `$` after them.
 
 ```typescript
 asyncShadowRootQuerySelector(selectors): Promise<ShadowRoot | null>;
@@ -331,6 +504,8 @@ asyncShadowRootQuerySelector(root, selectors, asyncParams): Promise<ShadowRoot |
 ```
 
 #### AsyncSelector class
+
+This class creates an instance of an element that could be used to perform asynchronous query selections in the DOM tree passing through the `shadowRoot` of elements.
 
 ```typescript
 new AsyncSelector();
@@ -368,10 +543,12 @@ The instances of this class have the next properties:
 
 And the next methods:
 
-| Method                    | Return                     | Description                                                      |
-| ------------------------- | -------------------------- | ---------------------------------------------------------------- |
-| `eq(index: number)`       | `Promise<Element \| null>` | Returns a promise that resolves in the element in the index position of the queried elements (startig from `0`) |
-| `query(selector: string)` | `AsyncSelector`            | Performs a query and returns a new AsyncSelector instance |
+| Method                        | Return                     | Description                                                      |
+| ----------------------------- | -------------------------- | ---------------------------------------------------------------- |
+| `eq(index: number)`           | `Promise<Element \| null>` | Returns a promise that resolves in the element in the index position of the queried elements (startig from `0`) |
+| `query(selector: string)`     | `AsyncSelector`            | Performs a query and returns a new AsyncSelector instance |
+| `deepQuery(selector: string)` | `AsyncSelector`            | Performs a deep query (even through elements' shadowRoot) ans returns a new AsyncSelector instance |
+
 
 ##### Examples of the AsyncSelector class
 
@@ -392,6 +569,8 @@ await selector.query('section').$.element === document.querySelector('section').
 await selector.query('section').$.all; // Empty Node list
 await selector.query('section').$.query('article').all === document.querySelector('section').shadowRoot.querySelectorAll('article');
 await selector.query('section').$.query('ul li').eq(1) === document.querySelector('section').shadowRoot.querySelectorAll('ul li')[1];
+await selector.deepQuery('li.delayed-li').element; // try to query the element deep in the shadowDOM tree until the retries/delay expire
+await selector.deepQuery('li.delayed-li').all; // try to perform a querySelectorAll deep in the shadowDOM tree until the retries/delay expire
 selector.query('section').$.query('article').asyncParams; // { retries: 100, delay: 50 }
 ```
 

--- a/cypress/e2e/async-selector.spec.cy.ts
+++ b/cypress/e2e/async-selector.spec.cy.ts
@@ -148,6 +148,136 @@ describe('ShadowDomSelector AsyncSelector class spec', () => {
 
     });
 
+    it('Deep query for delayed elements from document', () => {
+
+        cy.window()
+            .then(async (win) => {
+
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+
+                const selector = new AsyncSelector({
+                    retries: 60,
+                    delay: 10
+                });
+                
+                expect(
+                    await selector.deepQuery('.delayed-list-container').element
+                ).not.null;
+
+                expect(
+                    await selector.query('section').deepQuery('.delayed-list-container').element
+                ).not.null;
+
+                expect(
+                    (await selector.deepQuery('li.delayed-li').all).length
+                ).to.equal(3);
+
+                expect(
+                    await selector.deepQuery('li.delayed-li').eq(2)
+                ).to.text('Delayed List item 3');
+
+                expect(
+                    await selector.deepQuery('li.delayed-li:nth-of-type(2)').element
+                ).to.text('Delayed List item 2');
+
+                expect(
+                    await selector.deepQuery('.non-existent-element').element
+                ).to.null;
+
+                expect(
+                    await selector.query('.non-existent-element').deepQuery('ul').element
+                ).to.null;
+
+            });
+
+    });
+
+    it('Deep query for delayed elements from element', () => {
+
+        cy.window()
+            .then(async (win) => {
+
+                const doc = win.document;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+
+                const selector = new AsyncSelector(
+                    doc.querySelector('section'),
+                    {
+                        retries: 60,
+                        delay: 10
+                    }
+                );
+
+                // From an element
+                expect(
+                    await selector.deepQuery('.delayed-list-container').element
+                ).not.null;
+
+                expect(
+                    (await selector.deepQuery('li.delayed-li').all).length
+                ).to.equal(3);
+
+                expect(
+                    await selector.deepQuery('li.delayed-li').eq(2)
+                ).to.text('Delayed List item 3');
+
+                expect(
+                    await selector.deepQuery('li.delayed-li:nth-of-type(2)').element
+                ).to.text('Delayed List item 2');
+
+                expect(
+                    await selector.deepQuery('.non-existent-element').element
+                ).to.null;
+
+                expect(
+                    await selector.deepQuery('.non-existent-element').element
+                ).to.null;
+
+            });
+
+    });
+
+    it('Deep query for delayed elements from shadowRoot', () => {
+
+        cy.window()
+            .then(async (win) => {
+
+                const doc = win.document;
+                const AsyncSelector = win.ShadowDomSelector.AsyncSelector;
+
+                const selector = new AsyncSelector(
+                    doc.querySelector('section').shadowRoot,
+                    {
+                        retries: 60,
+                        delay: 10
+                    }
+                );
+
+                // From a shadow Root
+                expect(
+                    await selector.deepQuery('.delayed-list-container').element
+                ).not.null;
+
+                expect(
+                    (await selector.deepQuery('li.delayed-li').all).length
+                ).to.equal(3);
+
+                expect(
+                    await selector.deepQuery('li.delayed-li').eq(2)
+                ).to.text('Delayed List item 3');
+
+                expect(
+                    await selector.deepQuery('li.delayed-li:nth-of-type(2)').element
+                ).to.text('Delayed List item 2');
+
+                expect(
+                    await selector.deepQuery('.non-existent-element').element
+                ).to.null;
+
+            });
+
+    });
+
     it('Inherited params', () => {
 
         cy.window()

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         setTimeout(() => {
             const delayedList = document.createElement('ul');
-            delayedList.innerHTML = ELEMENTS_STRINGS.list.map(text => `<li>Delayed ${text}</li>`).join('');
+            delayedList.innerHTML = ELEMENTS_STRINGS.list.map(text => `<li class="delayed-li">Delayed ${text}</li>`).join('');
             const shadowDelayedList = delayedListContainer.attachShadow({ mode: 'open' });
             shadowDelayedList.appendChild(delayedList);
         }, 500);


### PR DESCRIPTION
This pull request implements new method to query for elements in the DOM tree through elements' shadowRoot.

Usage of the new methods:

```typescript
import {
  deepQuerySelector,
  deepQuerySelectorAll,
  asyncDeepQuerySelector,
  asyncDeepQuerySelectorAll
} from 'shadow-dom-selector';

// searches for the first li in the DOM tree passing through elements' shadowRoot
const deepFirstLi = deepQuerySelector('li');

// performs a querySelectorAll of the first group of li elements in the DOM tree passing through elements' shadowRoot
const deepAllLi = deepQuerySelectorAll('li');

asyncDeepQuerySelector('h1')
  .then((h1) => {
      // Do stuff with the h1 element
      // If it is not found after all the retries, it will return null
  });

asyncDeepQuerySelectorAll('p')
  .then((paragraphs) => {
      // Do stuff with the paragraphs
      // If they are not found after all the retries, it will return an empty NodeList
  });
```

