### PR TITLE
Library refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.1.0] - 2023-12-16
+
+- Refactor the whole library to reduce repetitive and unnecessary code
+- All the methods admit at the moment a `shadowRoot` as a root element
+
 ## [4.0.0] - 2023-12-15
 
 - Implement a `deepQuerySelector` method to query for elements even if they are deep in the shadowDOM tree

--- a/cypress/e2e/methods.spec.cy.ts
+++ b/cypress/e2e/methods.spec.cy.ts
@@ -116,9 +116,17 @@ describe('ShadowDomSelector spec', () => {
                 expect(
                     () => querySelector('$ section$ article')
                 ).to.throw(
-                    'You can not select a shadowRoot'
+                    'You can not select a shadowRoot ($) of the document'
                 );
-        
+
+                expect(
+                    () => querySelector(
+                        doc.querySelector('section').shadowRoot,
+                        '$ article'
+                    )
+                ).to.throw(
+                    'You can not select a shadowRoot ($) of a shadowRoot'
+                );
 
             });
     });
@@ -206,7 +214,16 @@ describe('ShadowDomSelector spec', () => {
                 expect(
                     () => querySelectorAll('$ section$ article$ ul')
                 ).to.throw(
-                    'You can not select a shadowRoot'
+                    'You can not select a shadowRoot ($) of the document'
+                );
+
+                expect(
+                    () => querySelectorAll(
+                        doc.querySelector('section').shadowRoot,
+                        '$ article'
+                    )
+                ).to.throw(
+                    'You can not select a shadowRoot ($) of a shadowRoot'
                 );
 
             });
@@ -297,13 +314,22 @@ describe('ShadowDomSelector spec', () => {
                 expect(
                     () => shadowRootQuerySelector('$ section$ article$')
                 ).to.throw(
-                    'You can not select a shadowRoot'
+                    'You can not select a shadowRoot ($) of the document'
                 );
 
                 expect(
                     () => shadowRootQuerySelector('$')
                 ).to.throw(
-                    'You can not select a shadowRoot'
+                    'You can not select a shadowRoot ($) of the document'
+                );
+
+                expect(
+                    () => shadowRootQuerySelector(
+                        doc.querySelector('section').shadowRoot,
+                        '$'
+                    )
+                ).to.throw(
+                    'You can not select a shadowRoot ($) of a shadowRoot'
                 );
 
             });
@@ -412,7 +438,17 @@ describe('ShadowDomSelector spec', () => {
                 cy.wrap(null).then(() => {
                     return asyncQuerySelector('$ section$ article')
                         .catch((error: Error) => {
-                            expect(error.message).to.contain('You can not select a shadowRoot');
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of the document');
+                        });
+                });
+
+                cy.wrap(null).then(() => {
+                    return asyncQuerySelector(
+                        doc.querySelector('section').shadowRoot,
+                        '$ article'
+                    )
+                        .catch((error: Error) => {
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of a shadowRoot');
                         });
                 });
 
@@ -583,7 +619,17 @@ describe('ShadowDomSelector spec', () => {
                 cy.wrap(null).then(() => {
                     return asyncQuerySelectorAll('$ section$ article li')
                         .catch((error: Error) => {
-                            expect(error.message).to.contain('You can not select a shadowRoot');
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of the document');
+                        });
+                });
+
+                cy.wrap(null).then(() => {
+                    return asyncQuerySelectorAll(
+                        doc.querySelector('section').shadowRoot,
+                        '$ article'
+                    )
+                        .catch((error: Error) => {
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of a shadowRoot');
                         });
                 });
 
@@ -789,14 +835,24 @@ describe('ShadowDomSelector spec', () => {
                 cy.wrap(null).then(() => {
                     return asyncShadowRootQuerySelector('$ section$ article$')
                         .catch((error: Error) => {
-                            expect(error.message).to.contain('You can not select a shadowRoot');
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of the document');
                         });
                 });
 
                 cy.wrap(null).then(() => {
                     return asyncShadowRootQuerySelector('$')
                         .catch((error: Error) => {
-                            expect(error.message).to.contain('You can not select a shadowRoot');
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of the document');
+                        });
+                });
+
+                cy.wrap(null).then(() => {
+                    return asyncShadowRootQuerySelector(
+                        doc.querySelector('section').shadowRoot,
+                        '$'
+                    )
+                        .catch((error: Error) => {
+                            expect(error.message).to.contain('You can not select a shadowRoot ($) of a shadowRoot');
                         });
                 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,17 @@ import {
     SHADOW_ROOT_SELECTOR,
 } from '@constants';
 import * as lib from '@lib';
-import {
-    isParamsWithRoot,
-    getPromisableShadowRoot,
-    getPromisableElement,
-    getElementPromise
-} from '@utilities';
+import { isParamsWithRoot, getElementPromise } from '@utilities';
 
 export function querySelector<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string
 ): E | null;
 export function querySelector<E extends Element = Element>(
     selectors: string
 ): E | null;
 export function querySelector<E extends Element = Element>(
-    ...params: [Document | Element, string] | [string]
+    ...params: [Document | Element | ShadowRoot, string] | [string]
 ): E | null {
     const [rootOrSelector, selectors] = params;
     if (typeof rootOrSelector === 'string') {
@@ -37,14 +32,14 @@ export function querySelector<E extends Element = Element>(
 }
 
 export function deepQuerySelector<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string
 ): E | null;
 export function deepQuerySelector<E extends Element = Element>(
     selectors: string
 ): E | null;
 export function deepQuerySelector<E extends Element = Element>(
-    ...params: [Document | Element, string] | [string]
+    ...params: [Document | Element | ShadowRoot, string] | [string]
 ): E | null {
     const [rootOrSelector, selectors] = params;
     if (typeof rootOrSelector === 'string') {
@@ -66,14 +61,14 @@ export function deepQuerySelector<E extends Element = Element>(
 }
 
 export function querySelectorAll<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string
 ): NodeListOf<E>;
 export function querySelectorAll<E extends Element = Element>(
     selectors: string
 ): NodeListOf<E>;
 export function querySelectorAll<E extends Element = Element>(
-    ...params: [Document | Element, string] | [string]
+    ...params: [Document | Element | ShadowRoot, string] | [string]
 ): NodeListOf<E> {
     const [rootOrSelector, selectors] = params;
     if (typeof rootOrSelector === 'string') {
@@ -89,14 +84,14 @@ export function querySelectorAll<E extends Element = Element>(
 }
 
 export function deepQuerySelectorAll<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string
 ): NodeListOf<E>;
 export function deepQuerySelectorAll<E extends Element = Element>(
     selectors: string
 ): NodeListOf<E>;
 export function deepQuerySelectorAll<E extends Element = Element>(
-    ...params: [Document | Element, string] | [string]
+    ...params: [Document | Element | ShadowRoot, string] | [string]
 ): NodeListOf<E> {
     const [rootOrSelector, selectors] = params;
     if (typeof rootOrSelector === 'string') {
@@ -112,14 +107,14 @@ export function deepQuerySelectorAll<E extends Element = Element>(
 }
 
 export function shadowRootQuerySelector(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string
 ): ShadowRoot | null;
 export function shadowRootQuerySelector(
     selectors: string
 ): ShadowRoot | null;
 export function shadowRootQuerySelector(
-    ...params: [Document | Element, string] | [string]
+    ...params: [Document | Element | ShadowRoot, string] | [string]
 ): ShadowRoot | null {
     const [rootOrSelector, selectors] = params;
     if (typeof rootOrSelector === 'string') {
@@ -135,7 +130,7 @@ export function shadowRootQuerySelector(
 }
 
 export async function asyncQuerySelector<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string,
     asyncParams?: AsyncParams,
 ): Promise<E | null >;
@@ -144,7 +139,7 @@ export async function asyncQuerySelector<E extends Element = Element>(
     asyncParams?: AsyncParams,
 ): Promise<E | null >;
 export async function asyncQuerySelector<E extends Element = Element>(
-    ...params: [Document | Element, string, AsyncParams?] | [string, AsyncParams?]
+    ...params: [Document | Element | ShadowRoot, string, AsyncParams?] | [string, AsyncParams?]
 ): Promise<E | null > {
 
     if (isParamsWithRoot(params)) {
@@ -168,7 +163,7 @@ export async function asyncQuerySelector<E extends Element = Element>(
 }
 
 export async function asyncDeepQuerySelector<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string,
     asyncParams?: AsyncParams,
 ): Promise<E | null >;
@@ -177,7 +172,7 @@ export async function asyncDeepQuerySelector<E extends Element = Element>(
     asyncParams?: AsyncParams,
 ): Promise<E | null >;
 export async function asyncDeepQuerySelector<E extends Element = Element>(
-    ...params: [Document | Element, string, AsyncParams?] | [string, AsyncParams?]
+    ...params: [Document | Element | ShadowRoot, string, AsyncParams?] | [string, AsyncParams?]
 ): Promise<E | null > {
 
     if (isParamsWithRoot(params)) {
@@ -212,7 +207,7 @@ export async function asyncDeepQuerySelector<E extends Element = Element>(
 }
 
 export async function asyncQuerySelectorAll<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string,
     asyncParams?: AsyncParams
 ): Promise<NodeListOf<E>>;
@@ -221,7 +216,7 @@ export async function asyncQuerySelectorAll<E extends Element = Element>(
     asyncParams?: AsyncParams
 ): Promise<NodeListOf<E>>;
 export async function asyncQuerySelectorAll<E extends Element = Element>(
-    ...params: [Document | Element, string, AsyncParams?] | [string, AsyncParams?]
+    ...params: [Document | Element | ShadowRoot, string, AsyncParams?] | [string, AsyncParams?]
 ): Promise<NodeListOf<E>> {
     
     if (isParamsWithRoot(params)) {
@@ -245,7 +240,7 @@ export async function asyncQuerySelectorAll<E extends Element = Element>(
 }
 
 export function asyncDeepQuerySelectorAll<E extends Element = Element>(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string,
     asyncParams?: AsyncParams
 ): Promise<NodeListOf<E>>;
@@ -254,7 +249,7 @@ export function asyncDeepQuerySelectorAll<E extends Element = Element>(
     asyncParams?: AsyncParams
 ): Promise<NodeListOf<E>>;
 export function asyncDeepQuerySelectorAll<E extends Element = Element>(
-    ...params: [Document | Element, string, AsyncParams?] | [string, AsyncParams?]
+    ...params: [Document | Element | ShadowRoot, string, AsyncParams?] | [string, AsyncParams?]
 ): Promise<NodeListOf<E>> {
 
     if (isParamsWithRoot(params)) {
@@ -279,7 +274,7 @@ export function asyncDeepQuerySelectorAll<E extends Element = Element>(
 }
 
 export async function asyncShadowRootQuerySelector(
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
     selectors: string,
     asyncParams?: AsyncParams
 ): Promise<ShadowRoot | null>;
@@ -288,7 +283,7 @@ export async function asyncShadowRootQuerySelector(
     asyncParams?: AsyncParams
 ): Promise<ShadowRoot | null>;
 export async function asyncShadowRootQuerySelector(
-    ...params: [Document | Element, string, AsyncParams?] | [string, AsyncParams?]
+    ...params: [Document | Element | ShadowRoot, string, AsyncParams?] | [string, AsyncParams?]
 ): Promise<ShadowRoot | null> {
 
     if (isParamsWithRoot(params)) {
@@ -372,16 +367,16 @@ export class AsyncSelector<T extends Document | Element | ShadowRoot> {
                     return null;
                 }
                 if (element instanceof NodeList) {
-                    return getPromisableShadowRoot(
+                    return asyncShadowRootQuerySelector(
                         element[0],
-                        this._asyncParams.retries,
-                        this._asyncParams.delay
+                        SHADOW_ROOT_SELECTOR,
+                        this._asyncParams
                     );
                 }
-                return getPromisableShadowRoot(
+                return asyncShadowRootQuerySelector(
                     element,
-                    this._asyncParams.retries,
-                    this._asyncParams.delay
+                    SHADOW_ROOT_SELECTOR,
+                    this._asyncParams
                 );
             });
         return new AsyncSelector(
@@ -430,20 +425,16 @@ export class AsyncSelector<T extends Document | Element | ShadowRoot> {
                     return null;
                 }
                 if (element instanceof NodeList) {
-                    return getPromisableElement(
+                    return asyncQuerySelectorAll(
                         element[0],
                         selector,
-                        this._asyncParams.retries,
-                        this._asyncParams.delay,
-                        true
+                        this._asyncParams
                     );
                 }
-                return getPromisableElement(
+                return asyncQuerySelectorAll(
                     element,
                     selector,
-                    this._asyncParams.retries,
-                    this._asyncParams.delay,
-                    true
+                    this._asyncParams
                 );
             });
         return new AsyncSelector<Element>(

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -1,13 +1,9 @@
 import { HOST_SELECTOR } from '@constants';
-import {
-    getPromisableElement,
-    getPromisableShadowRoot,
-    getDocumentShadowRootError
-} from '@utilities';
+import { getDocumentShadowRootError, getShadowRootShadowRootError } from '@utilities';
 
 export function querySelectorInternal<E extends Element>(
     path: string[],
-    root: Document | Element,
+    root: Document | Element | ShadowRoot,
 ): E | null {
 
     let foundElement: E | null = null;
@@ -20,6 +16,11 @@ export function querySelectorInternal<E extends Element>(
                 if (root instanceof Document) {
                     throw new SyntaxError(
                         getDocumentShadowRootError()
+                    );
+                }
+                if (root instanceof ShadowRoot) {
+                    throw new SyntaxError(
+                        getShadowRootShadowRootError()
                     );
                 }
                 foundElement = root.shadowRoot?.querySelector(path[++index]) || null;
@@ -40,7 +41,7 @@ export function querySelectorInternal<E extends Element>(
 
 export function querySelectorAllInternal<E extends Element>(
     path: string[],
-    root: Document | Element
+    root: Document | Element | ShadowRoot
 ): NodeListOf<E> | null {
 
     const pathLocal = [...path];
@@ -57,7 +58,7 @@ export function querySelectorAllInternal<E extends Element>(
     );
  
     return (
-        lastElement.shadowRoot?.querySelectorAll<E>(`${HOST_SELECTOR} ${lastSelector}`) ||
+        lastElement?.shadowRoot?.querySelectorAll<E>(`${HOST_SELECTOR} ${lastSelector}`) ||
         null
     );
 
@@ -65,7 +66,7 @@ export function querySelectorAllInternal<E extends Element>(
 
 export function shadowRootQuerySelectorInternal(
     path: string[],
-    root: Document | Element
+    root: Document | Element | ShadowRoot
 ): ShadowRoot | null {
 
     if (
@@ -77,6 +78,11 @@ export function shadowRootQuerySelectorInternal(
                 getDocumentShadowRootError()
             );
         }
+        if (root instanceof ShadowRoot) {
+            throw new SyntaxError(
+                getShadowRootShadowRootError()
+            );
+        }
         return root.shadowRoot;
     }
 
@@ -86,164 +92,5 @@ export function shadowRootQuerySelectorInternal(
     );
 
     return lastElement?.shadowRoot || null;
-
-}
-
-export async function asyncQuerySelectorInternal<E extends Element>(
-    path: string[],
-    root: Document | Element,
-    retries: number,
-    delay: number
-): Promise<E | null> {
-
-    let foundElement: E | null = null;
-
-    const total = path.length;
-
-    for (let index = 0; index < total; index++) {
-
-        if (index === 0) {
-
-            if (!path[index].length) {
-
-                if (root instanceof Document) {
-                    throw new SyntaxError(
-                        getDocumentShadowRootError()
-                    );
-                }
-
-                foundElement = root.shadowRoot
-                    ? await getPromisableElement<E>(
-                        root.shadowRoot,
-                        path[++index],
-                        retries,
-                        delay
-                    )
-                    : null;
-
-            } else {
-
-                foundElement = await getPromisableElement<E>(
-                    root,
-                    path[index],
-                    retries,
-                    delay
-                );
-
-            }
-
-        } else {
-
-            const shadowRoot = await getPromisableShadowRoot(
-                foundElement,
-                retries,
-                delay
-            );
-
-            foundElement = shadowRoot
-                ? await getPromisableElement<E>(
-                    shadowRoot,
-                    `${HOST_SELECTOR} ${path[index]}`,
-                    retries,
-                    delay
-                )
-                : null;
-        }
-
-        if (foundElement === null) {
-            return null;
-        }
-
-    }
-
-    return foundElement;
-
-}
-
-export async function asyncQuerySelectorAllInternal<E extends Element>(
-    path: string[],
-    root: Document | Element,
-    retries: number,
-    delay: number
-): Promise<NodeListOf<E> | null> {
-
-    const pathLocal = [...path];
-
-    const lastSelector = pathLocal.pop();
-
-    if (!pathLocal.length) {
-        return await getPromisableElement<E>(
-            root,
-            lastSelector,
-            retries,
-            delay,
-            true
-        );
-    }
-
-    const lastElement = await asyncQuerySelectorInternal(
-        pathLocal,
-        root,
-        retries,
-        delay
-    );
-
-    const shadowRoot = lastElement
-        ? await getPromisableShadowRoot(
-            lastElement,
-            retries,
-            delay
-        )
-        : null;
-
-    return shadowRoot
-        ? await getPromisableElement<E>(
-            shadowRoot,
-            `${HOST_SELECTOR} ${lastSelector}`,
-            retries,
-            delay,
-            true
-        )
-        : null;
-
-}
-
-export async function asyncShadowRootQuerySelectorInternal(
-    path: string[],
-    root: Document | Element,
-    retries: number,
-    delay: number
-): Promise<ShadowRoot | null> {
-
-    if (
-        path.length === 1 &&
-        !path[0].length
-    ) {
-        if (root instanceof Document) {
-            throw new SyntaxError(
-                getDocumentShadowRootError()
-            );
-        }
-        return getPromisableShadowRoot(
-            root,
-            retries,
-            delay
-        );
-    }
-
-    const lastElement = await asyncQuerySelectorInternal(
-        path,
-        root,
-        retries,
-        delay
-    );
-
-    return lastElement
-        ? await getPromisableShadowRoot(
-            lastElement,
-            retries,
-            delay
-        )
-        : null;
 
 }


### PR DESCRIPTION
This pull request refactors the the whole library to reduce repetitive and unnecessary code. It also makes it possible to send a `ShadowRoot` element as the `root` element from which perform a query.