### PR TITLE
Publish the package using npm provenance

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     container:
       image: cypress/browsers
     steps:
@@ -28,7 +30,7 @@ jobs:
       - name: Publish
         run: |
           yarn install --frozen-lockfile
-          npm publish
+          npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.1.1] - 2023-12-19
+
+- Publish the package using npm provenance
+
 ## [4.1.0] - 2023-12-16
 
 - Refactor the whole library to reduce repetitive and unnecessary code


### PR DESCRIPTION
This pull request adds [the --provenance flag](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) to the `npm publish` command in the deploy workflow.