### PR TITLE
Cache Docker images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Publish
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,10 @@ jobs:
           path: |
             ~/.cache
           key: dependencies-v1-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.6
+        with:
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('package.json') }}
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Linting Code


### PR DESCRIPTION
This pull request uses the action [ScribeMD/docker-cache](https://github.com/ScribeMD/docker-cache) to cache Docker images during the workflow pipelines.