### PR TITLE
Add a pre-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:run": "playwright test",
     "test:open": "playwright test --ui",
     "test:ci": "pnpm clean && start-server-and-test demo http://localhost:3000 test:run",
+    "preinstall": "npx -y only-allow pnpm",
     "prepare": "pnpm build",
     "prepublishOnly": "pnpm lint && pnpm test:ts && pnpm test:ci",
     "version": "git add .",


### PR DESCRIPTION
Add a preinstall script to avoid using another package manager different from `pnpm`.