### PR TITLE
Avoid Dependabot rollup updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     commit-message:
       prefix: "[Dependencies]"
     ignore:
+      ## Ignoring rollup until the issue with Error: server closed unexpectedly is solved
+      ## It doesn't happen in rollup v4.21.0
+      - dependency-name: rollup
       - dependency-name: "rollup-plugin-serve"
     groups:
       dependencies-dev:


### PR DESCRIPTION
This pull request excludes rollup from Dependabot updates. After version `4.21.0` starting a server using `start-server-and-test` ends up in:

```
> shadow-dom-selector@4.1.2 test:ci /home/runner/work/shadow-dom-selector/shadow-dom-selector
> pnpm clean && start-server-and-test 'pnpm demo' http://localhost:3000 'pnpm test:run'


> shadow-dom-selector@4.1.2 clean /home/runner/work/shadow-dom-selector/shadow-dom-selector
> rm -rf dist .nyc_output coverage || true

1: starting server using command "pnpm demo"
and when url "[ 'http://localhost:3000' ]" is responding with HTTP status code 200
running tests using command "pnpm test:run"


> shadow-dom-selector@4.1.2 demo /home/runner/work/shadow-dom-selector/shadow-dom-selector
> rollup --config rollup.test.config.js --bundleConfigAsCjs -w

Error: server closed unexpectedly
    at ChildProcess.onClose (/home/runner/work/shadow-dom-selector/shadow-dom-selector/node_modules/.pnpm/start-server-and-test@2.0.6/node_modules/start-server-and-test/src/index.js:[8](https://github.com/elchininet/shadow-dom-selector/actions/runs/10757386433/job/29831361013?pr=79#step:8:9)3:14)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:10[9](https://github.com/elchininet/shadow-dom-selector/actions/runs/10757386433/job/29831361013?pr=79#step:8:10)8:16)
    at ChildProcess._handle.onexit (node:internal/child_process:303:5)
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```