### PR TITLE
Add a default shell script to get TTY and avoid it being undefined on CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,9 @@
 name: Deploy
 
+defaults:
+  run:
+    shell: 'script -q /dev/null bash -e {0}'
+
 on:
   push:
     tags:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,9 @@
 name: Tests
 
+defaults:
+  run:
+    shell: 'script -q /dev/null bash -e {0}'
+
 on:
   push:
     branches:


### PR DESCRIPTION
This pull request adds a default shell script to the workflows that use tests to get TTY and solve [this issue](https://github.com/rollup/rollup/issues/5641).