### PR TITLE
Set get-promisable-result as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.0.1] - 2024-11-10
+
+- Remove `get-promisable-result` package as a peer dependency and set it as a dependency
+
 ## [5.0.0] - 2024-11-10
 
 - Set `get-promisable-result` package as a peer dependency and create a separate bundle for web

--- a/README.md
+++ b/README.md
@@ -197,24 +197,22 @@ Either the async methods or the async dot notation allow you to to specify the a
 
 ## Install
 
-The package needs the [get-promisable-result](https://github.com/elchininet/get-promisable-result) package as a peer dependency.
-
 #### npm
 
 ```bash
-npm install get-promisable-result shadow-dom-selector
+npm install shadow-dom-selector
 ```
 
 #### yarn
 
 ```bash
-yarn add get-promisable-result shadow-dom-selector
+yarn add shadow-dom-selector
 ```
 
 #### PNPM
 
 ```bash
-pnpm add get-promisable-result shadow-dom-selector
+pnpm add shadow-dom-selector
 ```
 
 #### In the browser

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.8.7",
     "eslint": "^9.14.0",
-    "get-promisable-result": "^1.0.1",
     "globals": "^15.11.0",
     "nyc": "^17.1.0",
     "playwright-test-coverage": "^1.2.12",
@@ -74,7 +73,7 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.12.2"
   },
-  "peerDependencies": {
-    "get-promisable-result": "^1.0.0"
+  "dependencies": {
+    "get-promisable-result": "^1.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      get-promisable-result:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.48.2
@@ -26,9 +30,6 @@ importers:
       eslint:
         specifier: ^9.14.0
         version: 9.14.0
-      get-promisable-result:
-        specifier: ^1.0.1
-        version: 1.0.1
       globals:
         specifier: ^15.11.0
         version: 15.11.0


### PR DESCRIPTION
This pull request adds the `get-promisable-result` package as a dependency